### PR TITLE
fix argparse type error: replaced 'str' with str

### DIFF
--- a/opts.py
+++ b/opts.py
@@ -95,17 +95,17 @@ class opts:
         )
         self.parser.add_argument(
             '--root_dataset',
-            type='str',
+            type=str,
             default='/data/dyh/data/MOTChallenge'
         )
         self.parser.add_argument(
             '--path_AFLink',
-            type='str',
+            type=str,
             default='/data/dyh/results/StrongSORT_Git/AFLink_epoch20.pth'
         )
         self.parser.add_argument(
             '--dir_save',
-            type='str',
+            type=str,
             default='/data/dyh/results/StrongSORT_Git/tmp'
         )
         self.parser.add_argument(


### PR DESCRIPTION
This pull request fixes a `ValueError` caused by incorrectly using the string 'str' instead of the type `str` in the `argparse` argument definitions within `opts.py`. 

Changes include:
- Correcting the `type` parameter in `add_argument` calls for `--root_dataset`, `--path_AFLink`, and `--dir_save` to use `str` instead of `'str'`.

These changes resolve the error and ensure the script runs correctly. Please review and merge.
