### PR TITLE
Updated deprecated functions and types

### DIFF
--- a/application_util/preprocessing.py
+++ b/application_util/preprocessing.py
@@ -37,7 +37,7 @@ def non_max_suppression(boxes, max_bbox_overlap, scores=None):
     if len(boxes) == 0:
         return []
 
-    boxes = boxes.astype(np.float)
+    boxes = boxes.astype(float)
     pick = []
 
     x1 = boxes[:, 0]

--- a/deep_sort/linear_assignment.py
+++ b/deep_sort/linear_assignment.py
@@ -1,7 +1,7 @@
 # vim: expandtab:ts=4:sw=4
 from __future__ import absolute_import
 import numpy as np
-from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment 
 from . import kalman_filter
 from opts import opt
 
@@ -58,7 +58,8 @@ def min_cost_matching(
 
     cost_matrix_ = cost_matrix.copy()
 
-    indices = linear_assignment(cost_matrix_)
+    row_indices, col_indices = linear_sum_assignment(cost_matrix_)
+    indices = np.column_stack((row_indices, col_indices))
 
     matches, unmatched_tracks, unmatched_detections = [], [], []
     for col, detection_idx in enumerate(detection_indices):

--- a/deep_sort_app.py
+++ b/deep_sort_app.py
@@ -115,7 +115,7 @@ def create_detections(detection_mat, frame_idx, min_height=0):
         Returns detection responses at given frame index.
 
     """
-    frame_indices = detection_mat[:, 0].astype(np.int)
+    frame_indices = detection_mat[:, 0].astype(int)
     mask = frame_indices == frame_idx
 
     detection_list = []

--- a/tools/generate_detections.py
+++ b/tools/generate_detections.py
@@ -56,7 +56,7 @@ def extract_image_patch(image, bbox, patch_shape):
 
     # convert to top left, bottom right
     bbox[2:] += bbox[:2]
-    bbox = bbox.astype(np.int)
+    bbox = bbox.astype(int)
 
     # clip at image boundaries
     bbox[:2] = np.maximum(0, bbox[:2])
@@ -162,9 +162,9 @@ def generate_detections(encoder, mot_dir, output_dir, detection_dir=None):
         detections_in = detections_in[detections_in[:, 6] >= 0.6]  # dyh
         detections_out = []
 
-        frame_indices = detections_in[:, 0].astype(np.int)
-        min_frame_idx = frame_indices.astype(np.int).min()
-        max_frame_idx = frame_indices.astype(np.int).max()
+        frame_indices = detections_in[:, 0].astype(int)
+        min_frame_idx = frame_indices.astype(int).min()
+        max_frame_idx = frame_indices.astype(int).max()
         for frame_idx in range(min_frame_idx, max_frame_idx + 1):
             # print("Frame %05d/%05d" % (frame_idx, max_frame_idx))
             mask = frame_indices == frame_idx


### PR DESCRIPTION
This pull request updates deprecated functions and data types to ensure compatibility with recent versions of the dependencies, as the repository does not specify package versions. 

Changes include:

- Replaced sklearn.utils.linear_assignment_ with scipy.optimize.linear_sum_assignment (since linear_assignment is deprecated in sklearn).
- Replaced np.int with int (deprecated in NumPy).
- Replaced np.float with float (deprecated in NumPy).